### PR TITLE
fix php warning if checkedEmailForMembers is not set

### DIFF
--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -31,7 +31,7 @@
  * Back end form fields
  */
 $GLOBALS['BE_FFL']['checkedEmail'] = 'TextField';
-if ($GLOBALS['TL_CONFIG']['checkedEmailForMembers'] && TL_MODE == 'BE')
+if (array_key_exists("checkedEmailForMembers", $GLOBALS['TL_CONFIG']) && $GLOBALS['TL_CONFIG']['checkedEmailForMembers'] && TL_MODE == 'BE')
 {
   $GLOBALS['BE_FFL']['checkedEmail']        = 'CliffParnitzky\CheckedEmail';
   $GLOBALS['TL_JAVASCRIPT']['checkedEmail'] = 'bundles/cliffparnitzkyformcheckedemail/checkedEmail.js';


### PR DESCRIPTION
Tested on Contao 4.13.30, PHP 8.2.9.


```
ErrorException:
Warning: Undefined array key "checkedEmailForMembers"

  at vendor/cliffparnitzky/checked-email/src/Resources/contao/config/config.php:34
  at include('/kunden/489660_94036/contao-2023/vendor/cliffparnitzky/checked-email/src/Resources/contao/config/config.php')
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/Config.php:198)
  at Contao\Config->initialize()
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/Config.php:163)
  at Contao\Config::getInstance()
     (vendor/contao/core-bundle/src/Framework/Adapter.php:46)
  at Contao\CoreBundle\Framework\Adapter->__call()
     (vendor/contao/core-bundle/src/Framework/ContaoFramework.php:298)
  at Contao\CoreBundle\Framework\ContaoFramework->initializeFramework()
     (vendor/contao/core-bundle/src/Framework/ContaoFramework.php:122)
  at Contao\CoreBundle\Framework\ContaoFramework->initialize()
     (vendor/contao/core-bundle/src/Routing/RouteProvider.php:46)
  at Contao\CoreBundle\Routing\RouteProvider->getRouteCollectionForRequest()
     (vendor/symfony-cmf/routing/src/NestedMatcher/NestedMatcher.php:140)
  at Symfony\Cmf\Component\Routing\NestedMatcher\NestedMatcher->matchRequest()
     (vendor/symfony-cmf/routing/src/DynamicRouter.php:272)
  at Symfony\Cmf\Component\Routing\DynamicRouter->matchRequest()
     (vendor/symfony-cmf/routing/src/ChainRouter.php:188)
  at Symfony\Cmf\Component\Routing\ChainRouter->doMatch()
     (vendor/symfony-cmf/routing/src/ChainRouter.php:158)
  at Symfony\Cmf\Component\Routing\ChainRouter->matchRequest()
     (vendor/symfony/http-kernel/EventListener/RouterListener.php:111)
  at Symfony\Component\HttpKernel\EventListener\RouterListener->onKernelRequest()
     (vendor/symfony/event-dispatcher/Debug/WrappedListener.php:118)
  at Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke()
     (vendor/symfony/event-dispatcher/EventDispatcher.php:230)
  at Symfony\Component\EventDispatcher\EventDispatcher->callListeners()
     (vendor/symfony/event-dispatcher/EventDispatcher.php:59)
  at Symfony\Component\EventDispatcher\EventDispatcher->dispatch()
     (vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:154)
  at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch()
     (vendor/symfony/http-kernel/HttpKernel.php:139)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:59)                
```